### PR TITLE
Refactor: Correct ProviderFirebaseDataSource and its Impl

### DIFF
--- a/app/src/main/java/com/example/gestiontienda2/data/remote/firebase/datasource/ProviderFirebaseDataSource.kt
+++ b/app/src/main/java/com/example/gestiontienda2/data/remote/firebase/datasource/ProviderFirebaseDataSource.kt
@@ -1,4 +1,4 @@
-package com.gestiontienda2.data.remote.firebase.datasource
+package com.example.gestiontienda2.data.remote.firebase.datasource
 
 import com.example.gestiontienda2.data.remote.firebase.models.ProviderFirebase
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/com/example/gestiontienda2/data/remote/firebase/datasource/impl/ProviderFirebaseDataSourceImpl.kt
+++ b/app/src/main/java/com/example/gestiontienda2/data/remote/firebase/datasource/impl/ProviderFirebaseDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.example.gestiontienda2.data.remote.firebase.datasource.impl
 
 import com.google.firebase.firestore.FirebaseFirestore
 import com.example.gestiontienda2.data.remote.firebase.models.ProviderFirebase
+import com.example.gestiontienda2.data.remote.firebase.datasource.ProviderFirebaseDataSource
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
@@ -10,9 +11,8 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ProviderFirebaseDataSourceImpl @Inject constructor
-
-private val firestore: FirebaseFirestore = TODO()
+class ProviderFirebaseDataSourceImpl @Inject constructor(
+    private val firestore: FirebaseFirestore
 ) : ProviderFirebaseDataSource {
 
     private val providersCollection = firestore.collection("providers")


### PR DESCRIPTION
This commit addresses issues in `ProviderFirebaseDataSource.kt` (interface) and `ProviderFirebaseDataSourceImpl.kt` (implementation):

- I corrected the package declaration in `ProviderFirebaseDataSource.kt` to align with the project structure (`com.example.gestiontienda2.data.remote.firebase.datasource`).
- I fixed a critical syntax error in the constructor of `ProviderFirebaseDataSourceImpl.kt`. `FirebaseFirestore` is now correctly injected.
- I added the required import for the `ProviderFirebaseDataSource` interface in `ProviderFirebaseDataSourceImpl.kt`.
- I verified that other imports, DI annotations (`@Singleton`, `@Inject`), and method implementations (Firebase API usage, error handling, Flow construction) are structurally sound.
- I noted a potential area for improvement in `addProvider` regarding the handling of default empty string IDs in the `ProviderFirebase` model, though no change was made to this logic in this commit.