### PR TITLE
Fix: Correct null handling in ClientFirebase mappers

### DIFF
--- a/app/src/main/java/com/example/gestiontienda2/data/local/room/entities/mapper/ClientMapper.kt
+++ b/app/src/main/java/com/example/gestiontienda2/data/local/room/entities/mapper/ClientMapper.kt
@@ -11,7 +11,7 @@ fun ClientFirebase.toEntity() = ClientEntity(
     email = email ?: "", // Handle null email from Firebase
     address = address ?: "", // Map Firebase address, default to empty if null
     paymentPreference = paymentPreference ?: "", // Map Firebase preference, default to empty if null
-    phone = phone
+    phone = phone ?: ""
 )
 
 fun ClientFirebase.toDomain() = Client(
@@ -20,7 +20,7 @@ fun ClientFirebase.toDomain() = Client(
     email = email, // Domain Client email is nullable
     address = address ?: "", // Map Firebase address, default to empty if null
     paymentPreference = paymentPreference ?: "", // Map Firebase preference, default to empty if null
-    phone = phone
+    phone = phone ?: ""
 )
 
 fun ClientEntity.toDomain() = Client(


### PR DESCRIPTION
This commit addresses specific type mismatches in ClientMapper.kt you reported, primarily related to nullability when mapping from ClientFirebase:

1.  In `ClientFirebase.toEntity()`:
    - Changed the `phone` field mapping from `phone` to `phone ?: ""` to correctly handle cases where `ClientFirebase.phone` is null and `ClientEntity.phone` is non-nullable.

2.  In `ClientFirebase.toDomain()`:
    - Changed the `phone` field mapping from `phone` to `phone ?: ""` to correctly handle cases where `ClientFirebase.phone` is null and `Client.phone` (domain model) is non-nullable.

All other mappings in `ClientMapper.kt` were re-verified for type consistency and correct null handling against the latest model definitions. The previously reported 'Int to String' mismatch in `ClientFirebase.toDomain()` was not identified in the current codebase.