### PR TITLE
Fix: Resolve conflicting client mapper definitions

### DIFF
--- a/app/src/main/java/com/example/gestiontienda2/data/local/room/entities/mapper/MapperExtensions.kt
+++ b/app/src/main/java/com/example/gestiontienda2/data/local/room/entities/mapper/MapperExtensions.kt
@@ -1,44 +1,5 @@
 package com.example.gestiontienda2.data.local.room.entities.mapper
 
-import com.example.gestiontienda2.data.local.room.entities.entity.ClientEntity
-import com.example.gestiontienda2.data.remote.firebase.models.ClientFirebase
-import com.example.gestiontienda2.domain.models.Client
-
-
-fun ClientFirebase.toEntity(): ClientEntity {
-    return ClientEntity(
-        id = id.toIntOrNull() ?: 0,
-        name = name,
-        email = email.toString(),
-        phone = phone
-    )
-}
-
-fun ClientEntity.toDomain(): Client {
-    return Client(
-        id = id,
-        name = name,
-        email = email,
-        phone = phone
-    )
-}
-
-fun Client.toEntity(): ClientEntity {
-    return ClientEntity(
-        id = id,
-        name = name,
-        email = email.toString(),
-        phone = phone
-    )
-}
-
-fun Client.toFirebase(): ClientFirebase {
-    return ClientFirebase(
-        id2 = id.toIntOrNull() ?: 0,
-        id1 = id.toIntOrNull() ?: 0,
-        id = id.toString(),
-        name = name,
-        email = email,
-        phone = phone
-    )
-}
+// Client-specific mapper extensions (ClientFirebase.toEntity, ClientEntity.toDomain, Client.toEntity, Client.toFirebase)
+// have been removed from this file.
+// These are now centralized in ClientMapper.kt or are no longer needed due to direct use of mappers.

--- a/app/src/main/java/com/example/gestiontienda2/data/local/room/entities/mapper/Mappers.kt
+++ b/app/src/main/java/com/example/gestiontienda2/data/local/room/entities/mapper/Mappers.kt
@@ -7,25 +7,7 @@ import com.example.gestiontienda2.data.local.room.entities.entity.OrderItemEntit
 import com.example.gestiontienda2.data.local.room.entities.entity.ProductEntity
 import com.example.gestiontienda2.domain.models.*
 
-// ---------- CLIENTES ----------
-
-fun ClientEntity.toDomain(): Client = Client(
-    id = this.id.toInt(),
-    name = this.name,
-    phone = this.phone,
-    address = this.address,
-    email = this.email,
-    paymentPreference = this.paymentPreference // Valor por defecto si es nulo
-)
-
-fun Client.toEntity(): ClientEntity = ClientEntity(
-    id = this.id,
-    name = this.name,
-    phone = this.phone,
-    address = this.address,
-    email = this.email ?: "",
-    paymentPreference = "efectivo" // Ajusta según lógica si tienes otras opciones
-)
+// Client mappers (ClientEntity.toDomain and Client.toEntity) removed, now centralized in ClientMapper.kt
 
 // ---------- PRODUCTOS ----------
 


### PR DESCRIPTION
This commit resolves 'Conflicting overloads' errors caused by multiple definitions of client-specific mapper extension functions across different files.

Client mapper functions were found to be defined in:
- `ClientMapper.kt` (intended single source of truth)
- `Mappers.kt` (contained conflicting versions of `ClientEntity.toDomain` and `Client.toEntity`)
- `MapperExtensions.kt` (contained conflicting and often incomplete/incorrect versions of all five core client mappers)

The conflicting client mapper definitions have been removed from `Mappers.kt` and `MapperExtensions.kt`. This ensures that `ClientMapper.kt` is the sole provider for these client mappers, eliminating ambiguity and ensuring the consistent, corrected versions are used.

- `MapperExtensions.kt` is now empty of these client mappers (and potentially other code if it only contained these).
- `Mappers.kt` now only contains non-client-specific mappers.
- `EntityMappers.kt` and `FirebaseMappers.kt` remain largely empty of client mappers as per previous refactorings.